### PR TITLE
The `<SendingInformationMessage/>` is not hovering

### DIFF
--- a/src/components/feedback/SendingInformation/index.tsx
+++ b/src/components/feedback/SendingInformation/index.tsx
@@ -147,6 +147,7 @@ const SendInformationMessage = (props: ISendInformationMessageProps) => {
                   appearance={appearance}
                   variant={buttonType}
                   spacing="compact"
+                  cursorHover
                 >
                   {sectionMessageConfig.cancelButton}
                 </Button>
@@ -155,6 +156,7 @@ const SendInformationMessage = (props: ISendInformationMessageProps) => {
                   appearance={appearance}
                   variant={buttonType}
                   spacing="compact"
+                  cursorHover
                 >
                   {sectionMessageConfig.agreeButton}
                 </Button>


### PR DESCRIPTION
The main of the app is to adjust user preferences, so, every available adjustment need an example.
However, the hovering has not.

The SendingInformationMessage component needs adjustments to represent the hovering effect.