### PR TITLE
Mock the downloadable documents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import { RespondInvitationRoutes } from "./routes/respondInvitation";
 import { PeopleRoutes } from "./routes/people";
 import { Login } from "./pages/login";
 import { intializedTokenData } from "@mocks/themeService/themeService.mock";
+import { intializedDocumentsData } from "@mocks/privileges/documentsService.mock";
+import localforage from "localforage";
 
 function LogOut() {
   localStorage.clear();
@@ -49,10 +51,13 @@ const router = createBrowserRouter(
 function App() {
   const { loginWithRedirect, isAuthenticated, isLoading } = useAuth0();
 
+  localforage.getItem("documents").then((data) => console.log(data, "data DB"));
+
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       loginWithRedirect();
       intializedTokenData();
+      intializedDocumentsData();
     }
   }, [isLoading, isAuthenticated, loginWithRedirect]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,6 @@ import { PeopleRoutes } from "./routes/people";
 import { Login } from "./pages/login";
 import { intializedTokenData } from "@mocks/themeService/themeService.mock";
 import { intializedDocumentsData } from "@mocks/privileges/documentsService.mock";
-import localforage from "localforage";
 
 function LogOut() {
   localStorage.clear();
@@ -50,8 +49,6 @@ const router = createBrowserRouter(
 
 function App() {
   const { loginWithRedirect, isAuthenticated, isLoading } = useAuth0();
-
-  localforage.getItem("documents").then((data) => console.log(data, "data DB"));
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {

--- a/src/components/feedback/SendingInformation/index.tsx
+++ b/src/components/feedback/SendingInformation/index.tsx
@@ -147,6 +147,7 @@ const SendInformationMessage = (props: ISendInformationMessageProps) => {
                   appearance={appearance}
                   variant={buttonType}
                   spacing="compact"
+                  cursorHover
                 >
                   {sectionMessageConfig.cancelButton}
                 </Button>
@@ -155,6 +156,7 @@ const SendInformationMessage = (props: ISendInformationMessageProps) => {
                   appearance={appearance}
                   variant={buttonType}
                   spacing="compact"
+                  cursorHover
                 >
                   {sectionMessageConfig.agreeButton}
                 </Button>

--- a/src/mocks/privileges/documentsService.mock.ts
+++ b/src/mocks/privileges/documentsService.mock.ts
@@ -1,0 +1,61 @@
+import localforage from "localforage";
+
+interface Document {
+  readonly id: number;
+  codigo: number;
+  nombre: string;
+}
+
+const DocumentsServiceMock = [
+  {
+    CODIGO: 1000,
+    NOMBRE:
+      "Certificacion de paz y salvo para creditos cancelados en los ultimos",
+  },
+  {
+    CODIGO: 1001,
+    NOMBRE: "Certificación saldos de Créditos",
+  },
+  {
+    CODIGO: 1004,
+    NOMBRE: "Certificado de créditos al día",
+  },
+  {
+    CODIGO: 1005,
+    NOMBRE: "Certificado saldos de aportes y ahorros",
+  },
+  {
+    CODIGO: 2003,
+    NOMBRE: "GR - CERTIFICADOS DE SALDOS Y PAGOS PARA EFECTOS TRIBUTARIOS",
+  },
+];
+
+export async function intializedDocumentsData() {
+  localforage.clear();
+
+  const documents = DocumentsServiceMock.map((document) => {
+    return {
+      id: document.CODIGO,
+      codigo: document.CODIGO,
+      nombre: document.NOMBRE,
+    };
+  });
+  await localforage.setItem("documents", documents);
+}
+
+export async function getDocuments(code: number): Promise<Document | void> {
+  const document: Document[] | null = await localforage.getItem("documents");
+  if (!document) return console.warn("No documents found");
+  return document.find((doc) => doc.codigo === code);
+}
+
+export async function updateDocument(
+  document: Document
+): Promise<Document | void> {
+  let documents: Document[] | null = await localforage.getItem("documents");
+  if (!documents) return console.warn("No documents found");
+  const index = documents.findIndex((doc) => doc.codigo === document.codigo);
+  documents[index] = document;
+  await localforage.setItem("documents", documents);
+  return document;
+}


### PR DESCRIPTION
Based on the service for the tokens, mock a service for the client-server app options. It should be loaded once the user access the privileges breadcrump. Each option will be an object with the keys: CODIGO and NOMBRE, the service should load an array with these options.