### PR TITLE
Fix the type issue in privileges related to the IClient

### DIFF
--- a/src/pages/people/outlets/color/strokes/form/RenderStrokesContentForm/interface.tsx
+++ b/src/pages/people/outlets/color/strokes/form/RenderStrokesContentForm/interface.tsx
@@ -3,7 +3,6 @@ import { Grid, inube, Stack, Text, useMediaQuery } from "@inube/design-system";
 import { IMessageState } from "@pages/privileges/outlets/users/types/forms.types";
 import { FieldsetColorCard } from "@components/cards/FieldsetColorCard";
 import { ThemeProvider } from "styled-components";
-import { Appearance } from "@components/feedback/SendingInformation/types";
 import { SendInformationMessage } from "@components/feedback/SendingInformation";
 import { strokesFormsConfig } from "@pages/people/outlets/color/strokes/config/Strokes.config";
 import { RenderMessage } from "@components/feedback/RenderMessage";
@@ -66,7 +65,7 @@ function RenderStrokesContentFormUI(props: RenderStrokesContentFormUIProps) {
         <ThemeProvider theme={updatedTheme}>
           <Stack direction="column" gap={inube.spacing.s350}>
             <SendInformationMessage
-              appearance={formType as Appearance}
+              appearance={formType as StrokeAppearance}
               buttonType="outlined"
             />
             <Grid

--- a/src/pages/people/outlets/color/strokes/form/RenderStrokesContentForm/interface.tsx
+++ b/src/pages/people/outlets/color/strokes/form/RenderStrokesContentForm/interface.tsx
@@ -65,7 +65,7 @@ function RenderStrokesContentFormUI(props: RenderStrokesContentFormUIProps) {
         <ThemeProvider theme={updatedTheme}>
           <Stack direction="column" gap={inube.spacing.s350}>
             <SendInformationMessage
-              appearance={formType as StrokeAppearance}
+              appearance={formType}
               buttonType="outlined"
             />
             <Grid

--- a/src/pages/people/outlets/color/surfaces/form/RenderContentFormSurface/interface.tsx
+++ b/src/pages/people/outlets/color/surfaces/form/RenderContentFormSurface/interface.tsx
@@ -11,7 +11,6 @@ import { StyledNavLinkContainer } from "./styles";
 import { IMessageState } from "@pages/privileges/outlets/users/types/forms.types";
 import { FieldsetColorCard } from "@components/cards/FieldsetColorCard";
 import { ThemeProvider } from "styled-components";
-import { Appearance } from "@components/feedback/SendingInformation/types";
 import { SendInformationMessage } from "@components/feedback/SendingInformation";
 import { surfaceFormsConfig } from "@pages/people/outlets/color/surfaces/config/surface.config";
 import { MdOutlineHouse } from "react-icons/md";
@@ -98,7 +97,7 @@ function RenderSurfaceContentFormUI(props: RenderSurfaceContentFormUIProps) {
 
             {formType !== "navLink" && (
               <SendInformationMessage
-                appearance={formType as Appearance}
+                appearance={formType as SurfaceAppearance}
                 buttonType="filled"
               />
             )}

--- a/src/pages/people/outlets/color/surfaces/form/RenderContentFormSurface/interface.tsx
+++ b/src/pages/people/outlets/color/surfaces/form/RenderContentFormSurface/interface.tsx
@@ -97,7 +97,7 @@ function RenderSurfaceContentFormUI(props: RenderSurfaceContentFormUIProps) {
 
             {formType !== "navLink" && (
               <SendInformationMessage
-                appearance={formType as SurfaceAppearance}
+                appearance={formType}
                 buttonType="filled"
               />
             )}

--- a/src/pages/people/outlets/typography/fonts/Fonts.stories.tsx
+++ b/src/pages/people/outlets/typography/fonts/Fonts.stories.tsx
@@ -2,7 +2,7 @@ import { StoryFn } from "@storybook/react";
 import { BrowserRouter } from "react-router-dom";
 import { Fonts } from "./index";
 import { TokenContext } from "@context/TokenContext";
-import { presente } from "@inube/design-system";
+import { presente } from "@src/mocks/design/tokensWithReference/presente";
 
 const story = {
   components: [Fonts],
@@ -14,7 +14,11 @@ const story = {
     (Story: StoryFn) => (
       <BrowserRouter>
         <TokenContext.Provider
-          value={{ token: presente, handleSubmit: () => {} }}
+          value={{
+            tokenWithRef: presente,
+            handleSubmit: () => {},
+            loading: false,
+          }}
         >
           <Story />
         </TokenContext.Provider>

--- a/src/pages/people/outlets/typography/fonts/form/RenderFormFonts/RenderFormFonts.stories.tsx
+++ b/src/pages/people/outlets/typography/fonts/form/RenderFormFonts/RenderFormFonts.stories.tsx
@@ -2,6 +2,8 @@ import { StoryFn } from "@storybook/react";
 import { BrowserRouter } from "react-router-dom";
 import { Stack } from "@inube/design-system";
 import { RenderFormFonts } from ".";
+import { presente } from "@src/mocks/design/tokensWithReference/presente";
+import { TokenContext } from "@context/TokenContext";
 
 const story = {
   components: [RenderFormFonts],
@@ -21,7 +23,15 @@ const story = {
 const Default = () => {
   return (
     <Stack padding="s300" direction="column">
-      <RenderFormFonts />
+      <TokenContext.Provider
+        value={{
+          tokenWithRef: presente,
+          handleSubmit: () => {},
+          loading: false,
+        }}
+      >
+        <RenderFormFonts />
+      </TokenContext.Provider>
     </Stack>
   );
 };

--- a/src/pages/respondInvitation/cases/ConfirmationRegisterComplete/index.tsx
+++ b/src/pages/respondInvitation/cases/ConfirmationRegisterComplete/index.tsx
@@ -8,9 +8,7 @@ function ConfirmationRegisterComplete() {
 
   const getClientData = () => {
     if (!client_id) return;
-    return clientsDataMock.find(
-      (clientMock) => clientMock.id === parseInt(client_id)
-    );
+    return clientsDataMock.find((clientMock) => clientMock.id === client_id);
   };
 
   const clientData = getClientData();

--- a/src/pages/respondInvitation/cases/ErrorInvitationExpired/index.tsx
+++ b/src/pages/respondInvitation/cases/ErrorInvitationExpired/index.tsx
@@ -1,6 +1,6 @@
 import Expired from "@assets/images/Expired.png";
 import { ErrorPage } from "@components/layout/ErrorPage";
-import { IClient } from "../../types";
+import { IClient } from "@context/AppContext/types";
 
 interface ErrorInvitationExpiredProps {
   clientData?: IClient;

--- a/src/pages/respondInvitation/cases/ErrorNotAvailable/index.tsx
+++ b/src/pages/respondInvitation/cases/ErrorNotAvailable/index.tsx
@@ -1,5 +1,5 @@
 import { ErrorPage } from "@components/layout/ErrorPage";
-import { IClient } from "../../types";
+import { IClient } from "@context/AppContext/types";
 
 interface ErrorNotAvailableProps {
   clientData?: IClient;

--- a/src/pages/respondInvitation/index.tsx
+++ b/src/pages/respondInvitation/index.tsx
@@ -36,9 +36,7 @@ function RespondInvitation() {
 
   const getClientData = () => {
     if (!client_id) return;
-    return clientsDataMock.find(
-      (clientMock) => clientMock.id === parseInt(client_id)
-    );
+    return clientsDataMock.find((clientMock) => clientMock.id === client_id);
   };
 
   const clientData = getClientData();

--- a/src/pages/respondInvitation/interface.tsx
+++ b/src/pages/respondInvitation/interface.tsx
@@ -22,7 +22,7 @@ import {
   StyledContainerHeader,
   StyledContainerForm,
 } from "./styles";
-import { IClient } from "./types";
+import { IClient } from "@context/AppContext/types";
 
 const renderHead = (clientData: IClient, smallScreen?: boolean) => {
   return (

--- a/src/pages/respondInvitation/types.ts
+++ b/src/pages/respondInvitation/types.ts
@@ -1,8 +1,0 @@
-interface IClient {
-  id: number;
-  name: string;
-  sigla: string;
-  logo: string;
-}
-
-export type { IClient };


### PR DESCRIPTION
The IClient type changes during the redefinition of the AppContext. The main change was the type of the id property, from number to string.

This causes several type errors on privileges outlets due to duplicity in the IClient type definition.

This adjustment includes deleting the double IClient definition and changing all of the import routes.

Set742: Warning and error messages were addressed by deleting/adjusting the appearance type callings in several color/domain/forms and replacing it with StrokesAppearance or SurfaceAppearance as needed.

Set743: The tokenContext was included into the storybook for RenderFormFonts to addressed the issue.

