### PR TITLE
Add AddRol component for assisted `Rol`

### DIFF
--- a/src/pages/privileges/outlets/assistedRoles/addRole/config/addRol.config.tsx
+++ b/src/pages/privileges/outlets/assistedRoles/addRole/config/addRol.config.tsx
@@ -1,0 +1,110 @@
+import { EAppearance } from "@src/types/colors.types";
+import { MdErrorOutline, MdThumbUpOffAlt } from "react-icons/md";
+
+import { Icon } from "@inube/design-system";
+
+export const stepsAddRol = {
+  generalInformation: {
+    id: 1,
+    label: "Información general",
+    description: "Por favor completa la información general.",
+  },
+  clientServerButton: {
+    id: 2,
+    label: "Selección botón cliente servidor",
+    description: "Por favor selecciona el botón cliente servidor.",
+  },
+  downloadableDocuments: {
+    id: 3,
+    label: "Formatos descargables",
+    description: "Asigna los formatos descargables.",
+  },
+  webReports: {
+    id: 4,
+    label: "Reportes web",
+    description: "Asigna los reportes web.",
+  },
+  webOptions: {
+    id: 5,
+    label: "Opciones web",
+    description: "Asigna las opciones web.",
+  },
+  clientServerReports: {
+    id: 6,
+    label: "Reportes cliente servidor",
+    description: "Asigna los reportes cliente servidor.",
+  },
+  clientServerOptions: {
+    id: 7,
+    label: "Opciones cliente servidor",
+    description: "Asigna las opciones cliente servidor.",
+  },
+  summary: {
+    id: 8,
+    label: "Verificación",
+    description:
+      "Verifica las opciones activadas, si es necesario cámbialas o por el contrario si todo está correcto dale enviar.",
+    isVerification: true,
+  },
+};
+
+export const createRolConfig = [
+  {
+    id: 1,
+    title: "Agregar rol",
+    description: "Completa la información para agregar rol",
+    route: "/privileges/roles/add-rol",
+    crumbs: [
+      {
+        path: "/",
+        label: "Inicio",
+        id: "/home",
+        isActive: false,
+      },
+      {
+        path: "/privileges",
+        label: "Privilegios",
+        id: "/privileges",
+        isActive: false,
+      },
+      {
+        path: "/privileges/linixUseCase",
+        label: "roles",
+        id: "/privileges/roles",
+        isActive: false,
+      },
+      {
+        path: "/privileges/linixUseCase/add-rol",
+        label: "Agregar un caso de uso",
+        id: "/privileges/linixUseCase/add-rol",
+        isActive: true,
+      },
+    ],
+  },
+];
+
+export const finishAssistedRolModalConfig = {
+  title: "Finalizar registro",
+  description: "¿Está seguro de que desea finalizar el proceso de creación?",
+  actionText: "Finalizar",
+  appearance: EAppearance.SUCCESS,
+};
+
+export const finishAssistedRolMessagesConfig = {
+  success: {
+    id: 1,
+    icon: <Icon appearance="dark" icons={<MdThumbUpOffAlt />} size="18px" />,
+    title: "Creación exitosa",
+    description: (value: string) =>
+      `Hemos creado el caso de uso ${value} exitosamente.`,
+    appearance: EAppearance.SUCCESS,
+  },
+  failed: {
+    id: 2,
+    icon: <Icon appearance="dark" icons={<MdErrorOutline />} size="18px" />,
+    title: "¡Uy, algo ha salido mal!",
+    description: (value: string) =>
+      `Hemos presentado un error creando el caso de uso ${value}.`,
+    appearance: EAppearance.ERROR,
+  },
+};

--- a/src/pages/privileges/outlets/assistedRoles/addRole/config/index.tsx
+++ b/src/pages/privileges/outlets/assistedRoles/addRole/config/index.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+
+import { AddRolUI } from "./interface";
+import { stepsAddRol } from "./addRol.config";
+
+export function AddRol() {
+  const [currentStep, setCurrentStep] = useState<number>(
+    stepsAddRol.generalInformation.id
+  );
+  const [showModal, setShowModal] = useState(false);
+
+  const handleNextStep = (step: number) => {
+    setCurrentStep(step + 1);
+  };
+
+  const handlePrevStep = (step: number) => {
+    setCurrentStep(step - 1);
+  };
+
+  const handleCompleteInvitation = () => {
+    return;
+  };
+
+  const handleToggleModal = () => {
+    setShowModal((prevShowModal) => !prevShowModal);
+  };
+
+  return (
+    <AddRolUI
+      handlePrevStep={handlePrevStep}
+      handleNextStep={handleNextStep}
+      currentStep={currentStep}
+      handleToggleModal={handleToggleModal}
+      handleCompleteInvitation={handleCompleteInvitation}
+      showModal={showModal}
+    />
+  );
+}

--- a/src/pages/privileges/outlets/assistedRoles/addRole/config/interface.tsx
+++ b/src/pages/privileges/outlets/assistedRoles/addRole/config/interface.tsx
@@ -1,0 +1,161 @@
+import {
+  Assisted,
+  Breadcrumbs,
+  Stack,
+  useMediaQuery,
+} from "@inube/design-system";
+import itemNotFound from "@src/assets/images/ItemNotFound.png";
+
+import { DecisionModal } from "@components/feedback/DecisionModal";
+import { ItemNotFound } from "@components/layout/ItemNotFound";
+import { PageTitle } from "@components/PageTitle";
+import {
+  createRolConfig,
+  finishAssistedRolModalConfig,
+  stepsAddRol,
+} from "./addRol.config";
+
+interface AddRolUIProps {
+  handleNextStep: (step: number) => void;
+  handlePrevStep: (step: number) => void;
+  currentStep: number;
+  handleCompleteInvitation: () => void;
+  handleToggleModal: () => void;
+  showModal: boolean;
+}
+
+function finishModal(
+  handleCloseModal: () => void,
+  handleCompleteInvitation: () => void
+) {
+  const { title, description, actionText, appearance } =
+    finishAssistedRolModalConfig;
+
+  return (
+    <DecisionModal
+      title={title}
+      description={description}
+      actionText={actionText}
+      loading={false}
+      appearance={appearance}
+      closeModal={handleCloseModal}
+      handleClick={handleCompleteInvitation}
+    />
+  );
+}
+
+export function AddRolUI(props: AddRolUIProps) {
+  const {
+    currentStep,
+    handleCompleteInvitation,
+    handleToggleModal,
+    showModal,
+    handlePrevStep,
+    handleNextStep,
+  } = props;
+
+  const smallScreen = useMediaQuery("(max-width: 580px)");
+
+  return (
+    <Stack direction="column" padding={smallScreen ? "s200" : "s400 s800"}>
+      <Stack gap="48px" direction="column">
+        <Stack gap="32px" direction="column">
+          <Breadcrumbs crumbs={createRolConfig[0].crumbs} />
+          <Stack justifyContent="space-between" alignItems="center" gap="50px">
+            <PageTitle
+              title={createRolConfig[0].title}
+              description={createRolConfig[0].description}
+              navigatePage="/privileges/linixUseCase"
+            />
+          </Stack>
+        </Stack>
+        <>
+          <Assisted
+            steps={Object.values(stepsAddRol)}
+            currentStepId={currentStep}
+            handlePrev={handlePrevStep}
+            handleNext={
+              currentStep === Object.values(stepsAddRol).length
+                ? handleToggleModal
+                : handleNextStep
+            }
+          />
+
+          {currentStep === stepsAddRol.generalInformation.id && (
+            <ItemNotFound
+              image={itemNotFound}
+              title={"Información general"}
+              description={"Esta sección está en construcción."}
+              buttonDescription={"Retorna a la página de inicio"}
+              route={"/privileges/linixUseCase"}
+            />
+          )}
+          {currentStep === stepsAddRol.clientServerButton.id && (
+            <ItemNotFound
+              image={itemNotFound}
+              title={"Opciones botón cliente servidor"}
+              description={"Esta sección está en construcción."}
+              buttonDescription={"Retorna a la página de inicio"}
+              route={"/privileges/linixUseCase"}
+            />
+          )}
+          {currentStep === stepsAddRol.downloadableDocuments.id && (
+            <ItemNotFound
+              image={itemNotFound}
+              title={"Documentos descargables"}
+              description={"Esta sección está en construcción."}
+              buttonDescription={"Retorna a la página de inicio"}
+              route={"/privileges/linixUseCase"}
+            />
+          )}
+          {currentStep === stepsAddRol.webReports.id && (
+            <ItemNotFound
+              image={itemNotFound}
+              title={"Reportes web"}
+              description={"Esta sección está en construcción."}
+              buttonDescription={"Retorna a la página de inicio"}
+              route={"/privileges/linixUseCase"}
+            />
+          )}
+          {currentStep === stepsAddRol.webOptions.id && (
+            <ItemNotFound
+              image={itemNotFound}
+              title={"Opciones web"}
+              description={"Esta sección está en construcción."}
+              buttonDescription={"Retorna a la página de inicio"}
+              route={"/privileges/linixUseCase"}
+            />
+          )}
+          {currentStep === stepsAddRol.clientServerReports.id && (
+            <ItemNotFound
+              image={itemNotFound}
+              title={"Reportes cliente servidor"}
+              description={"Esta sección está en construcción."}
+              buttonDescription={"Retorna a la página de inicio"}
+              route={"/privileges/linixUseCase"}
+            />
+          )}
+          {currentStep === stepsAddRol.clientServerOptions.id && (
+            <ItemNotFound
+              image={itemNotFound}
+              title={"Opciones cliente servidor"}
+              description={"Esta sección está en construcción."}
+              buttonDescription={"Retorna a la página de inicio"}
+              route={"/privileges/linixUseCase"}
+            />
+          )}
+          {currentStep === stepsAddRol.summary.id && (
+            <ItemNotFound
+              image={itemNotFound}
+              title={"Página de resumen"}
+              description={"Esta sección está en construcción."}
+              buttonDescription={"Retorna a la página de inicio"}
+              route={"/privileges/linixUseCase"}
+            />
+          )}
+        </>
+      </Stack>
+      {showModal && finishModal(handleToggleModal, handleCompleteInvitation)}
+    </Stack>
+  );
+}

--- a/src/routes/privileges.tsx
+++ b/src/routes/privileges.tsx
@@ -8,6 +8,7 @@ import { ErrorPage } from "@components/layout/ErrorPage";
 import { CompleteInvitation } from "@pages/privileges/outlets/users/complete-invitation";
 import { LinixUseCase } from "@pages/privileges/outlets/linixUseCase";
 import { AddingLinixUseCase } from "@pages/privileges/outlets/linixUseCase/adding-linix-use-case";
+import { AddRol } from "@pages/privileges/outlets/assistedRoles/addRole/config";
 
 function PrivilegesRoutes() {
   return (
@@ -20,6 +21,7 @@ function PrivilegesRoutes() {
           path="linixUseCase/adding-linix-use-case"
           element={<AddingLinixUseCase />}
         />
+        <Route path="roles/add-rol" element={<AddRol />} />
         <Route path="users/invite" element={<Invite />} />
         <Route path="users/edit/:user_id" element={<EditUser />} />
         <Route


### PR DESCRIPTION
Create the assisted form skeleton for Adding Roles:

The test will be evaluated through the endpoint /roles/add-roles

It includes the config file creation with all of the steps, breadcrumbs, and a testing component for the outlets in each step.

It does not include the form submitting nor the general state for the form data.
