### PR TITLE
fix assisted add role navigation on mobile.

### DIFF
--- a/src/pages/privileges/outlets/roles/config/MenuAddRole.tsx
+++ b/src/pages/privileges/outlets/roles/config/MenuAddRole.tsx
@@ -5,7 +5,7 @@ export const menuInvitationLinks = [
   {
     id: "Create-role",
     label: "Agregar Roles",
-    path: "/privileges/roles",
+    path: "/privileges/roles/add-role",
     icon: <Icon icon={<MdPersonAddAlt />} size="16px" appearance="dark" />,
   },
 ];


### PR DESCRIPTION
Currently there is no navigation to the add role assistant when on mobile.