### PR TITLE
Include the storybook default documentation

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,6 +7,10 @@ export default {
     name: "@storybook/react-vite",
     options: {},
   },
+  docs: {
+    autodocs: true,
+    defaultName: "Documentation",
+  },
   async viteFinal(config) {
     return mergeConfig(config, {
       optimizeDeps: {


### PR DESCRIPTION
The autodocs property was assigned to true to include the auto-documentation in the components in the storybook.
![image](https://github.com/selsa-inube/isetting/assets/123512032/b3e368e6-487b-4b2c-bd9f-1b59f291ed2b)
