### PR TITLE
Adjust the General Information to require at least one

### DIFF
--- a/src/pages/privileges/outlets/linixUseCase/components/GeneralInformationForm/index.tsx
+++ b/src/pages/privileges/outlets/linixUseCase/components/GeneralInformationForm/index.tsx
@@ -20,6 +20,16 @@ const validationSchema = Yup.object({
   n_Usecase: Yup.string().required(validationMessages.required),
   i_Tipusec: Yup.string().required(validationMessages.required),
   n_Descrip: Yup.string().required(validationMessages.required),
+  k_Funcio: Yup.string(),
+  k_Opcion: Yup.string(),
+}).test(function (value) {
+  const { k_Funcio, k_Opcion } = value;
+  if (!k_Funcio && !k_Opcion) {
+    return this.createError({
+      path: "k_Funcio",
+    });
+  }
+  return true;
 });
 
 interface GeneralInformationFormProps {

--- a/src/pages/privileges/outlets/linixUseCase/components/GeneralInformationForm/interface.tsx
+++ b/src/pages/privileges/outlets/linixUseCase/components/GeneralInformationForm/interface.tsx
@@ -179,7 +179,7 @@ function RenderFormFields(
         />
       </Stack>
       <SearchUserCard
-        id="Opción cliente servido"
+        id="csSearch"
         label="Opción de menú cliente servidor Linix"
         placeholder="Seleccione una opción"
         name="csSearch"


### PR DESCRIPTION
Adjust the General Information in Linix Use Case to require at least 1 option between “opción web” and “opción cs”